### PR TITLE
Don't ship a live default password for the monitoring UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ docker run -d \
 | `MONITORING_UI_ENABLED` | Enable the built-in monitoring web UI (`true`/`false`) - see below | `false` |
 | `MONITORING_UI_LISTEN_ADDRESS` | Listen address for the monitoring UI | `127.0.0.1:8080` |
 | `MONITORING_UI_USERNAME` | Monitoring UI basic auth username | `admin` |
-| `MONITORING_UI_PASSWORD` | Monitoring UI basic auth password - **change this if you enable the UI** | `changeme` |
+| `MONITORING_UI_PASSWORD` | Monitoring UI basic auth password | random, generated at startup if `MONITORING_UI_ENABLED=true` and left unset |
 | `MONITORING_UI_PROMETHEUS_ENABLED` | Expose a `/metrics` endpoint on the monitoring UI (`true`/`false`) | `false` |
 | `IP_ENCRYPTION_ALGORITHM` | Encrypt client IPs in plugin logs - `none`, `ipcrypt-deterministic`, `ipcrypt-nd`, `ipcrypt-ndx` or `ipcrypt-pfx` | `none` |
 | `IP_ENCRYPTION_KEY` | Hex-encoded key for `IP_ENCRYPTION_ALGORITHM` (required if not `none`) | — |
@@ -94,12 +94,13 @@ services:
   dnscrypt-proxy:
     environment:
       - MONITORING_UI_ENABLED=true
-      - MONITORING_UI_PASSWORD=something-not-changeme
     ports:
       - "127.0.0.1:8080:8080"  # only if you need to reach it from outside the container
 ```
 
-The UI binds to loopback by default, so it isn't reachable unless you also publish its port. If you do publish it, set `MONITORING_UI_PASSWORD` to something other than the default first.
+The UI binds to loopback by default, so it isn't reachable unless you also publish its port.
+
+If you enable it without setting `MONITORING_UI_PASSWORD`, a random password is generated for that container's lifetime and printed once to the logs (`docker logs dnscrypt-proxy`) - there's no shipped default credential to forget to change. Set `MONITORING_UI_PASSWORD` explicitly if you'd rather pin it to something stable across restarts.
 
 ---
 

--- a/dnscrypt-proxy.toml
+++ b/dnscrypt-proxy.toml
@@ -1014,12 +1014,11 @@ enabled = %%MONITORING_UI_ENABLED%%
 listen_address = "%%MONITORING_UI_LISTEN_ADDRESS%%"
 
 ## Username and password for basic authentication.
-## Templated from MONITORING_UI_USERNAME / MONITORING_UI_PASSWORD.
+## Templated from MONITORING_UI_USERNAME / MONITORING_UI_PASSWORD. If the UI
+## is enabled without an explicit password, the init-dnscrypt-config oneshot
+## generates a random one at container start rather than shipping a fixed
+## default - see the README's Monitoring UI section.
 ## To disable authentication, set MONITORING_UI_USERNAME to an empty string.
-##
-## IMPORTANT: if you set MONITORING_UI_ENABLED=true, also set
-## MONITORING_UI_PASSWORD to something other than the default - see the
-## README's environment variable table.
 
 username = "%%MONITORING_UI_USERNAME%%"
 password = "%%MONITORING_UI_PASSWORD%%"

--- a/root/etc/s6-overlay/scripts/init-dnscrypt-config
+++ b/root/etc/s6-overlay/scripts/init-dnscrypt-config
@@ -1,5 +1,21 @@
 #!/usr/bin/with-contenv bash
 
+# Never fall through to a predictable default password for a UI that's
+# actually reachable. If it's enabled without an explicit password, generate
+# one instead of shipping "changeme" as a live credential - it only stays
+# "changeme" here when the UI is off (unreachable) and the value is moot.
+monitoring_ui_password="${MONITORING_UI_PASSWORD:-}"
+if [ -z "$monitoring_ui_password" ]; then
+    if [ "${MONITORING_UI_ENABLED:-false}" = "true" ]; then
+        for _ in $(seq 1 20); do
+            monitoring_ui_password+=$(printf '%x' $((RANDOM % 16)))
+        done
+        echo "[init-dnscrypt-config] MONITORING_UI_ENABLED=true but MONITORING_UI_PASSWORD was not set - generated a random password for this container's lifetime: ${monitoring_ui_password}"
+    else
+        monitoring_ui_password='changeme'
+    fi
+fi
+
 sed -i \
     -e "s/%%LOG_LEVEL%%/${LOG_LEVEL:-2}/" \
     -e "s/%%PORT%%/${PORT:-53}/" \
@@ -12,6 +28,6 @@ sed -i \
     -e "s/%%MONITORING_UI_ENABLED%%/${MONITORING_UI_ENABLED:-false}/" \
     -e "s#%%MONITORING_UI_LISTEN_ADDRESS%%#${MONITORING_UI_LISTEN_ADDRESS:-127.0.0.1:8080}#" \
     -e "s/%%MONITORING_UI_USERNAME%%/${MONITORING_UI_USERNAME:-admin}/" \
-    -e "s/%%MONITORING_UI_PASSWORD%%/${MONITORING_UI_PASSWORD:-changeme}/" \
+    -e "s/%%MONITORING_UI_PASSWORD%%/${monitoring_ui_password}/" \
     -e "s/%%MONITORING_UI_PROMETHEUS_ENABLED%%/${MONITORING_UI_PROMETHEUS_ENABLED:-false}/" \
     /etc/dnscrypt-proxy/dnscrypt-proxy.toml

--- a/root/etc/s6-overlay/scripts/init-dnscrypt-config
+++ b/root/etc/s6-overlay/scripts/init-dnscrypt-config
@@ -7,9 +7,10 @@
 monitoring_ui_password="${MONITORING_UI_PASSWORD:-}"
 if [ -z "$monitoring_ui_password" ]; then
     if [ "${MONITORING_UI_ENABLED:-false}" = "true" ]; then
-        for _ in $(seq 1 20); do
-            monitoring_ui_password+=$(printf '%x' $((RANDOM % 16)))
-        done
+        # Bash's $RANDOM is a weak, predictable PRNG - not suitable even for
+        # a "just don't ship a fixed password" fix. Read from /dev/urandom
+        # (kernel CSPRNG) instead: 16 bytes hex-encoded to a 32-char string.
+        monitoring_ui_password=$(od -An -tx1 -N16 /dev/urandom | tr -d ' \n')
         echo "[init-dnscrypt-config] MONITORING_UI_ENABLED=true but MONITORING_UI_PASSWORD was not set - generated a random password for this container's lifetime: ${monitoring_ui_password}"
     else
         monitoring_ui_password='changeme'


### PR DESCRIPTION
## Summary
- Flagged by an automated security review after the last push: `MONITORING_UI_PASSWORD` fell back to the literal string `changeme` whenever the monitoring UI was enabled without an explicit password, alongside the default username `admin` - a predictable, shipped credential for a real auth-gated endpoint.
- `changeme` is now only ever used when the UI is disabled (unreachable, so the value is moot). If `MONITORING_UI_ENABLED=true` and no password is supplied, the `init-dnscrypt-config` oneshot generates a random one for that container's lifetime and logs it once instead.
- Explicit `MONITORING_UI_PASSWORD` values still take priority and are used verbatim.
- Updated the README and the toml's own comments to match.

## Test plan
- [x] Built the image and verified `password = "changeme"` only appears when `MONITORING_UI_ENABLED` is unset/false
- [x] Verified `MONITORING_UI_ENABLED=true` with no password set generates and logs a random password, and templates it into the config
- [x] Verified an explicit `MONITORING_UI_PASSWORD` is used as-is
- [x] Ran `dnscrypt-proxy -config ... -check` against the real 2.1.16 binary - passes