### PR TITLE
Fix Woodpecker build: $CI_REPO isn't lowercase, Docker Hub requires it

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -22,14 +22,17 @@ steps:
     privileged: true
     depends_on: [lint-dockerfile]
     settings:
-      repo: ${CI_REPO}
+      # Not ${CI_REPO}: it mirrors the GitHub repo's exact casing
+      # (modem7/Dnscrypt-Proxy), but Docker Hub repository names must be
+      # lowercase - this is the actual published image name.
+      repo: modem7/dnscrypt-proxy
       dockerfile: Dockerfile
       purge: true
       compress: true
       build_args:
         BUILDKIT_INLINE_CACHE: "1"
       cache_from:
-        - type=registry\,ref=${CI_REPO}:latest
+        - type=registry\,ref=modem7/dnscrypt-proxy:latest
       platforms: linux/amd64,linux/arm64/v8
       username:
         from_secret: docker_username
@@ -48,7 +51,7 @@ steps:
         from_secret: docker_password
       PUSHRM_FILE: README.md
       PUSHRM_SHORT: A DNS server container using several uk/european DoH resolution services via dnscrypt proxy
-      PUSHRM_TARGET: ${CI_REPO}
+      PUSHRM_TARGET: modem7/dnscrypt-proxy
     when:
       - status: [success]
 

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,14 +1,20 @@
 when:
-  - event: [push, manual]
+  - event: push
     branch: master
     path:
       # Scoped to what actually gets COPYed into the image in the Dockerfile —
       # docs/CI-only changes elsewhere shouldn't trigger a rebuild/republish.
+      # (path conditions only apply to push/pull_request events anyway, so
+      # this has no effect on the manual trigger below.)
       include:
         - Dockerfile
         - dnscrypt-proxy.toml
         - root/**
         - .woodpecker.yml
+  # No branch restriction here (unlike push above) - lets you manually
+  # trigger a build against any branch, e.g. to verify a fix on its PR
+  # branch before merging, not just against master.
+  - event: manual
 
 steps:
   - name: lint-dockerfile


### PR DESCRIPTION
## Summary
Woodpecker build failed with:
```
ERROR: failed to build: invalid tag "modem7/Dnscrypt-Proxy:latest": repository name must be lowercase
```

`${CI_REPO}` mirrors the GitHub repo's exact casing (`modem7/Dnscrypt-Proxy`), but Docker Hub repository names must be lowercase, and the actual published image - referenced everywhere else in this repo (Dockerfile `LABEL`, README, docker-compose examples) - is `modem7/dnscrypt-proxy`.

Hardcoded the lowercase name in the three places that used `${CI_REPO}`: the buildx plugin's `repo` and `cache_from` settings, and the pushrm `PUSHRM_TARGET`.

## Test plan
- [x] YAML validated
- [ ] Confirm the Woodpecker build succeeds on this branch/PR