### PR TITLE
Release on both latest and the pinned dnscrypt-proxy version

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -23,13 +23,30 @@ steps:
       - hadolint --version
       - hadolint Dockerfile
 
+  # Writes a .tags file (one tag per line) for build-and-push to pick up via
+  # tags_file below - the plugin has no "release on latest + parsed version"
+  # feature of its own, but does read an arbitrary file of newline-separated
+  # tags at build time. Same branch/secrets scoping as build-and-push, since
+  # it exists solely to feed that step.
+  - name: compute-tags
+    image: alpine:edge
+    depends_on: [lint-dockerfile]
+    when:
+      - branch: master
+    commands:
+      - |
+        version=$(grep -oE "dnscrypt-proxy=[0-9]+\.[0-9]+\.[0-9]+" Dockerfile | cut -d= -f2)
+        [ -n "$version" ] || { echo "Could not extract dnscrypt-proxy version from Dockerfile" >&2; exit 1; }
+        printf 'latest\n%s\n' "$version" > .tags
+        cat .tags
+
   # Only runs on master (push or manual) - this is the one step with real
   # secrets (Docker Hub credentials), so it must not run for a manual
   # trigger against an arbitrary branch. See build-only below for that case.
   - name: build-and-push
     image: woodpeckerci/plugin-docker-buildx
     privileged: true
-    depends_on: [lint-dockerfile]
+    depends_on: [lint-dockerfile, compute-tags]
     when:
       - branch: master
     settings:
@@ -49,7 +66,9 @@ steps:
         from_secret: docker_username
       password:
         from_secret: docker_password
-      tags: latest
+      # Read from the .tags file compute-tags wrote (latest + the pinned
+      # dnscrypt-proxy version, e.g. 2.1.16) rather than a static tags: value.
+      tags_file: .tags
 
   # Runs for manual triggers on anything other than master - validates the
   # Dockerfile actually builds and the tag is well-formed (exactly the class

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ By default it routes every query through [Anonymized DNS](https://github.com/DNS
 
 | Tag | Description |
 | :---: | --- |
-| `latest` | Latest dnscrypt-proxy build |
+| `latest` | Latest build |
+| `X.Y.Z` (e.g. `2.1.16`) | Matches the dnscrypt-proxy version pinned in the [Dockerfile](Dockerfile) at build time - pin to this instead of `latest` if you want to control upgrades explicitly |
 
 ---
 


### PR DESCRIPTION
## Summary
Requested: Woodpecker should push both `latest` and a tag matching whatever dnscrypt-proxy version is currently pinned (e.g. `2.1.16`).

The `woodpeckerci/plugin-docker-buildx` plugin doesn't have a way to tag from an arbitrary version string directly - `auto_tag` only derives tags from git refs/tags, and `tags` is a static list. It does support `tags_file`, which reads an arbitrary file of newline-separated tags at build time.

Added a `compute-tags` step that:
- Extracts the version from the Dockerfile's `dnscrypt-proxy=X.Y.Z-rN` apk pin (e.g. `2.1.16`, dropping the `-rN` Alpine package revision suffix)
- Writes `latest` and that version to a `.tags` file
- Fails loudly if extraction comes up empty, rather than silently building with no tags

`build-and-push` now reads `tags_file: .tags` instead of a static `tags: latest`. Only runs on `branch: master`, same as `build-and-push` and `compute-tags` themselves - feeds directly into the existing secrets-scoping from the last PR.

Also updated the README's Tags table to document the new version tag.

## Test plan
- [x] Extraction command verified against the real Dockerfile inside the actual `alpine:edge` image the step uses - outputs `latest` / `2.1.16`
- [x] YAML validated
- [ ] Confirm the next master build actually pushes both `modem7/dnscrypt-proxy:latest` and `modem7/dnscrypt-proxy:2.1.16` to Docker Hub