### PR TITLE
Fail loudly if a config placeholder is left unrendered

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,14 @@ on:
       - Dockerfile
       - dnscrypt-proxy.toml
       - root/**
+      - .woodpecker.yml
       - .github/workflows/test.yml
   pull_request:
     paths:
       - Dockerfile
       - dnscrypt-proxy.toml
       - root/**
+      - .woodpecker.yml
       - .github/workflows/test.yml
   workflow_dispatch:
 
@@ -65,6 +67,28 @@ jobs:
       - uses: jbergstroem/hadolint-gh-action@v1
         with:
           dockerfile: Dockerfile
+
+  woodpecker-lint:
+    name: Validate .woodpecker.yml
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Parse YAML
+        run: python3 -c "import yaml; yaml.safe_load(open('.woodpecker.yml'))"
+      # The compute-tags step in .woodpecker.yml extracts the dnscrypt-proxy
+      # version from this exact pattern to tag Docker Hub releases - if the
+      # Dockerfile's pin format ever changes shape, that step fails silently
+      # in a way nothing here would otherwise catch (test.yml doesn't run the
+      # actual Woodpecker pipeline). Catch it here instead of finding out from
+      # a broken live release build.
+      - name: Confirm the version-tag extraction regex still matches the Dockerfile
+        run: |
+          version=$(grep -oE "dnscrypt-proxy=[0-9]+\.[0-9]+\.[0-9]+" Dockerfile | cut -d= -f2)
+          if [ -z "$version" ]; then
+            echo "::error::compute-tags' regex in .woodpecker.yml would fail to extract a version from the current Dockerfile"
+            exit 1
+          fi
+          echo "extracted version: $version"
 
   # ---------------------------------------------------------------------
   # Build + behavioral smoke test - most expensive, most likely to catch
@@ -134,6 +158,16 @@ jobs:
       - name: Check LOG_LEVEL env var is templated into the config by the init oneshot
         run: docker exec dnscrypt grep -q '^log_level = 0$' /etc/dnscrypt-proxy/dnscrypt-proxy.toml
 
+      # Broader than the LOG_LEVEL spot-check above: confirms every single
+      # %%PLACEHOLDER%% in the toml (not just the one we happened to override)
+      # got substituted by the real init-dnscrypt-config script, not a copy of
+      # its logic. Catches a new placeholder being added without a matching
+      # sed rule, or a rule silently breaking.
+      - name: Check no %%PLACEHOLDER%% tokens remain in the rendered config
+        run: |
+          count=$(docker exec dnscrypt grep -c '%%[A-Z_]\+%%' /etc/dnscrypt-proxy/dnscrypt-proxy.toml || true)
+          [ "${count:-0}" -eq 0 ]
+
       # The bootstrap resolvers in dnscrypt-proxy.toml (chosen for their no-log
       # policy, not for speed) are consistently slow or unreachable from GitHub
       # Actions' network - the full source-fetch fallback chain has taken up to
@@ -168,6 +202,93 @@ jobs:
 
       - name: Resolve a domain over TCP through the proxy
         run: dig @127.0.0.1 -p 5353 +tcp one.one.one.one +short +time=5 +tries=2 | grep -qE '^[0-9]+\.'
+
+      # Everything above only ever exercised each placeholder's *default*
+      # value (or, for LOG_LEVEL, one override) - nothing confirmed an
+      # explicitly-set env var actually reaches the config for the other 11
+      # placeholders. PORT in particular used to be a no-op bug (it only
+      # affected Docker/healthcheck metadata, never the real listen port) -
+      # this would have caught that. No port published: this container is
+      # only inspected via docker exec, not queried over the network.
+      - name: Start a second container with every templated setting overridden
+        run: |
+          docker run -d --name dnscrypt-custom \
+            -e PORT=5353 \
+            -e MAX_CLIENTS=42 \
+            -e CACHE_ENABLED=false \
+            -e CACHE_SIZE=1234 \
+            -e CACHE_MIN_TTL=60 \
+            -e MONITORING_UI_ENABLED=true \
+            -e MONITORING_UI_LISTEN_ADDRESS=127.0.0.1:9090 \
+            -e MONITORING_UI_USERNAME=testuser \
+            -e MONITORING_UI_PROMETHEUS_ENABLED=true \
+            -e IP_ENCRYPTION_ALGORITHM=ipcrypt-deterministic \
+            -e IP_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef \
+            dnscrypt-proxy:test
+          sleep 3
+
+      - name: Check every overridden setting was templated correctly
+        run: |
+          docker exec dnscrypt-custom grep -qF "listen_addresses = ['0.0.0.0:5353']" /etc/dnscrypt-proxy/dnscrypt-proxy.toml
+          docker exec dnscrypt-custom grep -q '^max_clients = 42$' /etc/dnscrypt-proxy/dnscrypt-proxy.toml
+          docker exec dnscrypt-custom grep -q '^cache = false$' /etc/dnscrypt-proxy/dnscrypt-proxy.toml
+          docker exec dnscrypt-custom grep -q '^cache_size = 1234$' /etc/dnscrypt-proxy/dnscrypt-proxy.toml
+          docker exec dnscrypt-custom grep -q '^cache_min_ttl = 60$' /etc/dnscrypt-proxy/dnscrypt-proxy.toml
+          docker exec dnscrypt-custom grep -q '^algorithm = "ipcrypt-deterministic"$' /etc/dnscrypt-proxy/dnscrypt-proxy.toml
+          docker exec dnscrypt-custom grep -q '^key = "0123456789abcdef0123456789abcdef"$' /etc/dnscrypt-proxy/dnscrypt-proxy.toml
+          docker exec dnscrypt-custom grep -q '^enabled = true$' /etc/dnscrypt-proxy/dnscrypt-proxy.toml
+          docker exec dnscrypt-custom grep -q '^listen_address = "127.0.0.1:9090"$' /etc/dnscrypt-proxy/dnscrypt-proxy.toml
+          docker exec dnscrypt-custom grep -q '^username = "testuser"$' /etc/dnscrypt-proxy/dnscrypt-proxy.toml
+          docker exec dnscrypt-custom grep -q '^prometheus_enabled = true$' /etc/dnscrypt-proxy/dnscrypt-proxy.toml
+
+      # MONITORING_UI_ENABLED=true above with no MONITORING_UI_PASSWORD set -
+      # this must trigger the random-password path (see the "don't ship a
+      # live default password" fix), not fall through to "changeme".
+      - name: Check a random monitoring UI password was generated and logged
+        run: |
+          docker logs dnscrypt-custom 2>&1 | grep -q "generated a random password"
+          # Extracted into a variable and checked by shape (length + character
+          # class) rather than a literal `password = "<hex-looking-value>"`
+          # pattern in this file, which GitGuardian's generic secret detector
+          # flags as a false positive even though it's just a test assertion.
+          value=$(docker exec dnscrypt-custom sh -c "grep '^password = ' /etc/dnscrypt-proxy/dnscrypt-proxy.toml" | cut -d'"' -f2)
+          [ "${#value}" -eq 32 ]
+          case "$value" in
+            *[!0-9a-f]*) echo "::error::generated password is not 32 lowercase hex characters: $value" >&2; exit 1 ;;
+          esac
+
+      - name: Check no %%PLACEHOLDER%% tokens remain with overridden env vars either
+        run: |
+          count=$(docker exec dnscrypt-custom grep -c '%%[A-Z_]\+%%' /etc/dnscrypt-proxy/dnscrypt-proxy.toml || true)
+          [ "${count:-0}" -eq 0 ]
+
+      # No dnscrypt-proxy -check here (unlike the first container): with a
+      # cold cache that can take several minutes, same issue as the first
+      # container before it was reordered after the healthy-wait. The grep
+      # checks above already confirm each value was templated with correct
+      # TOML syntax, and toml-lint separately confirms the overall file
+      # structure parses - not worth doubling this job's runtime to re-prove
+      # both of those together for this specific value combination.
+
+      - name: Stop second container
+        if: always()
+        run: docker rm -f dnscrypt-custom || true
+
+      # Regression test for the init script's safety net, not the daemon
+      # itself - runs last, against the already-running container, since it
+      # deliberately corrupts that container's on-disk config afterwards.
+      # Confirms an unmapped %%PLACEHOLDER%% actually fails the script with
+      # a clear error, instead of silently passing through to dnscrypt-proxy's
+      # generic TOML parse failure.
+      - name: Guard rejects an unmapped placeholder
+        run: |
+          docker exec dnscrypt sh -c '
+            sed -i "1i log_level_test = %%NOT_A_REAL_VAR%%" /etc/dnscrypt-proxy/dnscrypt-proxy.toml
+            if bash /etc/s6-overlay/scripts/init-dnscrypt-config; then
+              echo "::error::init script exited 0 despite an unmapped placeholder - the guard is not working" >&2
+              exit 1
+            fi
+          '
 
       - name: Stop container
         if: always()

--- a/root/etc/s6-overlay/scripts/init-dnscrypt-config
+++ b/root/etc/s6-overlay/scripts/init-dnscrypt-config
@@ -32,3 +32,15 @@ sed -i \
     -e "s/%%MONITORING_UI_PASSWORD%%/${monitoring_ui_password}/" \
     -e "s/%%MONITORING_UI_PROMETHEUS_ENABLED%%/${MONITORING_UI_PROMETHEUS_ENABLED:-false}/" \
     /etc/dnscrypt-proxy/dnscrypt-proxy.toml
+
+# Belt and braces: if a %%PLACEHOLDER%% was added to the toml without a
+# matching sed rule above, or this script somehow ran against the wrong
+# file, dnscrypt-proxy would otherwise fail with a cryptic TOML parse error
+# ("expected value but found '%' instead") with no hint as to why. Fail
+# loudly here instead, with the actual unrendered lines, before the daemon
+# ever gets a chance to start.
+if grep -q '%%[A-Z_]\+%%' /etc/dnscrypt-proxy/dnscrypt-proxy.toml; then
+    echo "[init-dnscrypt-config] FATAL: unrendered %%PLACEHOLDER%% tokens remain in dnscrypt-proxy.toml:" >&2
+    grep -n '%%[A-Z_]\+%%' /etc/dnscrypt-proxy/dnscrypt-proxy.toml >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
Every `%%PLACEHOLDER%%` in `dnscrypt-proxy.toml` already has a runtime default via bash's `${VAR:-default}` in the init script, so "env var not set" was already handled correctly. The actual gap: if the init oneshot ever failed to run at all, or a new placeholder got added to the toml without a matching `sed` rule, dnscrypt-proxy would fail with a cryptic TOML parse error (`expected value but found '%' instead`) with no indication of the real cause.

Considered baking real defaults into the image at build time instead, but decided against it - see the discussion in chat. That would trade a narrow, already-CI-tested risk (the init chain breaking, which isn't user-triggerable) for a broader one (13 hand-written anchored regexes replacing already-valid defaults instead of unique tokens, plus a second place that has to stay in sync with the runtime script's defaults).

Went with a much smaller fix: a guard after the `sed` pass that greps for any remaining `%%TOKEN%%` pattern and exits 1 with the actual offending line(s), before the daemon ever gets a chance to start on a broken config.

## Expanded CI coverage
A follow-up review found real gaps in what test.yml actually covered:
- 11 of 13 placeholders were only ever tested against their **default** value - `PORT` in particular was never tested with an override at all, despite being a real bug fixed earlier this session (it used to be a no-op, only touching Docker/healthcheck metadata, never the actual listen port).
- The random monitoring-UI-password generation logic had no test at all, despite being the subject of two prior security-review fixes.
- `.woodpecker.yml` had no validation in this workflow and wasn't even in the path filters, despite two real bugs in it this session (the lowercase Docker Hub tag, and a secrets-scoping issue).

Added:
- A second container start with **every** templated setting overridden at once, asserting each one actually landed in the config, that the password is a genuine 32-hex-char random string (not "changeme"), and that no placeholders remain.
- A `woodpecker-lint` job: validates `.woodpecker.yml`'s YAML syntax and confirms the `compute-tags` step's version-extraction regex still matches the Dockerfile, so a future format change fails here instead of on a live Woodpecker release build.

## Test plan
- [x] Normal build: guard is silent, zero remaining placeholders
- [x] Injected an unmapped `%%NOT_A_REAL_VAR%%` placeholder and confirmed the script fails with a clear, specific error instead of dnscrypt-proxy's generic TOML parse failure
- [x] All new templating/random-password/no-remaining-placeholder assertions replicated locally against the real image before pushing
- [x] `.woodpecker.yml` YAML validated and version-regex extraction confirmed locally