### PR TITLE
Extend shared renovate-config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,35 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
-  ],
-  "assignees": [
-    "modem7"
-  ],
-  "labels": [
-    "dependencies"
-  ],
-  "timezone": "Europe/London",
-  "packageRules": [
-    {
-      "description": "Automerge low-risk CI plumbing updates (GitHub Actions, Woodpecker step images) - Dockerfile base image and dnscrypt-proxy version stay manual",
-      "matchManagers": ["github-actions", "woodpecker"],
-      "matchUpdateTypes": ["minor", "patch", "digest"],
-      "automerge": true
-    }
+    "github>modem7/renovate-config",
+    "github>modem7/renovate-config:docker"
   ],
   "customManagers": [
-    {
-      "customType": "regex",
-      "description": "Track the S6 Overlay version pinned in the Dockerfile ARG",
-      "managerFilePatterns": ["/^Dockerfile$/"],
-      "matchStrings": [
-        "ARG S6_OVERLAY_VERSION=(?<currentValue>.+?)\\s"
-      ],
-      "datasourceTemplate": "github-releases",
-      "packageNameTemplate": "just-containers/s6-overlay",
-      "extractVersionTemplate": "^v(?<version>.*)$"
-    },
     {
       "customType": "regex",
       "description": "Track the dnscrypt-proxy Alpine edge package version pinned in the Dockerfile",


### PR DESCRIPTION
## Summary

- Replaces the local `renovate.json` CI-automerge packageRule (github-actions/woodpecker minor/patch/digest) and the `ARG S6_OVERLAY_VERSION` customManager with `extends: ["github>modem7/renovate-config", "github>modem7/renovate-config:docker"]` — both are now covered identically by the shared base and `:docker` presets.
- Keeps the customManager tracking the dnscrypt-proxy Alpine edge package version via repology — this is genuinely unique to this repo and isn't covered by any shared preset.

Note: this depends on [modem7/renovate-config#6](https://github.com/modem7/renovate-config/pull/6) merging for the new extends target to take full effect. That PR is green on CI but not yet merged — harmless in the meantime.

## Test plan

- [x] `npx --yes -p renovate renovate-config-validator` → "Config validated successfully"