### PR TITLE
ci: grant issues:write to auto-assign-pr job

### DIFF
--- a/.github/workflows/autoassign.yml
+++ b/.github/workflows/autoassign.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
     steps:
         - name: 'Auto-assign PR'
           uses: pozil/auto-assign-issue@v4.0.1


### PR DESCRIPTION
## Summary
- `auto-assign-pr` only declared `pull-requests: write`, but `pozil/auto-assign-issue` reads/writes assignees via the `/issues/{number}` API (PRs are issues under the hood), which needs `issues` scope
- GitHub granted this implicitly and inconsistently depending on the repo — some runs failed with `Resource not accessible by integration`
- Adds explicit `issues: write`, matching the sibling `auto-assign-issue` job

## Test plan
- [ ] Confirm the `auto-assign-pr` job succeeds on this PR